### PR TITLE
Add Typescript definition

### DIFF
--- a/lib/winston-socketio.d.ts
+++ b/lib/winston-socketio.d.ts
@@ -1,6 +1,7 @@
 import Transport from 'winston-transport';
 import { Socket } from 'socket.io-client';
-interface SocketIOOptions extends Transport.TransportStreamOptions {
+
+export interface SocketIOOptions extends Transport.TransportStreamOptions {
     secure?: boolean;
     host?: string;
     port?: number;

--- a/lib/winston-socketio.d.ts
+++ b/lib/winston-socketio.d.ts
@@ -1,0 +1,34 @@
+import Transport from 'winston-transport';
+import { Socket } from 'socket.io-client';
+interface SocketIOOptions extends Transport.TransportStreamOptions {
+    secure?: boolean;
+    host?: string;
+    port?: number;
+    reconnect?: boolean;
+    namespace?: string;
+    log_topic?: string;
+    log_format?: any;
+    max_queue_size?: number;
+}
+export declare class SocketIO extends Transport {
+    default_format: Function;
+    name: string;
+    secure: boolean;
+    host: string;
+    port: number;
+    reconnect: boolean;
+    namespace: string | null;
+    log_topic: string;
+    log_format: Function;
+    max_queue_size: number;
+    socket: typeof Socket;
+    _state: string;
+    _queue: Array<any>;
+    constructor(options: SocketIOOptions);
+    log(options: any, callback: Function): void;
+    open(callback: Function): void;
+    close(): void;
+    _enqueue(data: any): void;
+    _flushQueue(): void;
+}
+export default SocketIO;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.1",
   "description": "A winston transport that will emit logs to a socket.io server.",
   "main": "lib/winston-socketio.js",
+  "types": "lib/winston-socketio.d.ts",
   "scripts": {
     "test": "vows --spec --isolate"
   },


### PR DESCRIPTION
This adds a typescript definition.
I admit I am a noob with respect to Typescript, but the compiler was happy now I presented him the type definition, so I assume it to be good enough.

In order to enable other typescript projects use your module type safe, you have to publish the definition along with the module, see https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html